### PR TITLE
install script: treat path as a variable for zsh

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -169,7 +169,7 @@ fish)
 ;;
 
 zsh)
-  command="export PATH=$tilde_install_dir:PATH"
+  command="export PATH=$tilde_install_dir:\$PATH"
 
   zsh_config=$HOME/.zshrc
   tilde_zsh_config=$(tildify "$zsh_config")


### PR DESCRIPTION
Using PATH instead of $PATH inside the script string would cause the value of PATH to be set to the literal string "$tilde_install_dir:PATH". 

This means that instead of appending the value of PATH to $tilde_install_dir, it would literally append the string ":PATH".