### PR TITLE
Util: Fix search for .sylver caching dir

### DIFF
--- a/crates/sylver-core/src/util/fs.rs
+++ b/crates/sylver-core/src/util/fs.rs
@@ -15,16 +15,11 @@ pub fn find_upward_path(mut current_dir: PathBuf, name: &OsStr) -> anyhow::Resul
 }
 
 fn dir_entry_with_name(dir: &Path, name: &OsStr) -> anyhow::Result<Option<PathBuf>> {
-    for entry in dir.read_dir()? {
-        let dir = entry?;
-        let path = dir.path();
-
-        if path.is_dir() && path.file_name() == Some(name) {
-            return Ok(Some(path));
-        }
+    let candidate = dir.join(name);
+    match std::fs::metadata(&candidate) {
+        Ok(meta) if meta.is_dir() => Ok(Some(candidate)),
+        _ => Ok(None),
     }
-
-    Ok(None)
 }
 
 pub fn path_to_string(path: &Path) -> String {


### PR DESCRIPTION
[Bugfix]

I found a problem with the search for .sylver while using sylver on a machine which had a failed mounted directory.

Problem:
The `dir_entry_with_name` function performed a statx call on all entries/children of the given `dir`. For a path traversal up to the root directory '/' (as is the case the first time sylver is called), this can give performance issues for slow root level mounted directories ('/mount').

Solution:
Changed the implementation so only a single statx call is issued for the candidate path (`dir`/.sylver, e.g.: '/.sylver'), never on any siblings (e.g.: '/mount').