### PR TITLE
Feature request: Allow hash comments in .syl meta-lang spec

### DIFF
--- a/crates/sylver-dsl/src/meta/ast.rs
+++ b/crates/sylver-dsl/src/meta/ast.rs
@@ -1292,4 +1292,50 @@ pub mod test {
             },
         )
     }
+
+    #[test]
+    fn hash_comment_ignored_between_decls() {
+        test_parser(
+            MetaParser::parse(
+                Rule::main,
+                "# this is a comment\nterm INT = `[0-9]+`\n# another comment\nterm PLUS = '+'",
+            ),
+            main,
+            vec![
+                Decl::Terminal(TermDecl {
+                    name: "INT".into(),
+                    reg: parse_term_content("`[0-9]+`"),
+                    data: None,
+                }),
+                Decl::Terminal(TermDecl {
+                    name: "PLUS".into(),
+                    reg: parse_term_content("'+'"),
+                    data: None,
+                }),
+            ],
+        )
+    }
+
+    #[test]
+    fn hash_comment_inline_after_decl() {
+        test_parser(
+            MetaParser::parse(
+                Rule::main,
+                "term INT = `[0-9]+` # inline comment\nterm PLUS = '+'",
+            ),
+            main,
+            vec![
+                Decl::Terminal(TermDecl {
+                    name: "INT".into(),
+                    reg: parse_term_content("`[0-9]+`"),
+                    data: None,
+                }),
+                Decl::Terminal(TermDecl {
+                    name: "PLUS".into(),
+                    reg: parse_term_content("'+'"),
+                    data: None,
+                }),
+            ],
+        )
+    }
 }

--- a/crates/sylver-dsl/src/meta/meta.pest
+++ b/crates/sylver-dsl/src/meta/meta.pest
@@ -57,7 +57,8 @@ rule_decl = { "rule" ~ identifier ~ "=" ~ rule_exprs }
         rule_expr_ref = { identifier }
 
 
-main = { (node_decl | terminal | ignore_terminal | comment_terminal | rule_decl)+ ~ EOI }
+main = { SOI ~ (node_decl | terminal | ignore_terminal | comment_terminal | rule_decl)+ ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" | NEWLINE }
+COMMENT    = _{ "#" ~ (!NEWLINE ~ ANY)* }
 


### PR DESCRIPTION
A hash '#' marks the start of a comment until the end of the line. Added with unit tests.